### PR TITLE
Get Linux home directory from system info

### DIFF
--- a/BorisLib/Funcs_Files_Linux.h
+++ b/BorisLib/Funcs_Files_Linux.h
@@ -71,7 +71,7 @@ inline std::string GetUserDocumentsPath(void)
     pw = getpwuid(uid);
 	if (pw) {
 		
-		return std::string("/home/") + std::string(pw->pw_name) + std::string("/Documents/");
+		return std::string(pw->pw_dir) + std::string("/Documents/");
 	}
 	else return "";
 }


### PR DESCRIPTION
Hello,

The Boris code currently assumes (on Linux) that a user's home directory is always located at `/home/<username>`.  While that's generally true for personal machines and such, it's quite often _not_ true on larger multi-user systems such as research clusters.  This small patch uses the `pw_dir` attribute of the passwd struct instead to get the location from the system information, so as to always be correct.